### PR TITLE
Batch reveal updates

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -276,6 +276,25 @@ abstract contract BaseLaunchpeg is
         emit JoeFeeInitialized(_joeFeePercent, _joeFeeCollector);
     }
 
+    /// @notice Initialize batch reveal. Leave undefined to disable
+    /// batch reveal for the collection.
+    /// @dev Can only be set once. Cannot be initialized once sale has ended.
+    /// @param _batchReveal Batch reveal contract address
+    function initializeBatchReveal(address _batchReveal)
+        external
+        override
+        onlyOwner
+    {
+        if (address(batchReveal) != address(0)) {
+            revert Launchpeg__BatchRevealAlreadyInitialized();
+        }
+        // Disable once sale has ended
+        if (publicSaleEndTime > 0 && block.timestamp >= publicSaleEndTime) {
+            revert Launchpeg__WrongPhase();
+        }
+        batchReveal = IBatchReveal(_batchReveal);
+    }
+
     /// @notice Set the royalty fee
     /// @param _receiver Royalty fee collector
     /// @param _feePercent Royalty fee percent in basis point
@@ -401,12 +420,6 @@ abstract contract BaseLaunchpeg is
     {
         withdrawAVAXStartTime = _withdrawAVAXStartTime;
         emit WithdrawAVAXStartTimeSet(_withdrawAVAXStartTime);
-    }
-
-    /// @notice Update batch reveal
-    /// @dev Can be set to zero address to disable batch reveal
-    function setBatchReveal(address _batchReveal) external override onlyOwner {
-        batchReveal = IBatchReveal(_batchReveal);
     }
 
     /// @notice Mint NFTs to the project owner

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -7,6 +7,7 @@ error LaunchpegFactory__InvalidImplementation();
 
 // Launchpeg
 error Launchpeg__AllowlistBeforePreMint();
+error Launchpeg__BatchRevealAlreadyInitialized();
 error Launchpeg__BatchRevealDisabled();
 error Launchpeg__BatchRevealNotInitialized();
 error Launchpeg__BatchRevealStarted();

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -140,6 +140,7 @@ contract LaunchpegFactory is
     /// @param _amountForAuction Amount of NFTs available for the auction (e.g 8000)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
+    /// @param _enableBatchReveal Flag to enable batch reveal for the collection
     /// @return launchpeg New Launchpeg address
     function createLaunchpeg(
         string memory _name,
@@ -150,7 +151,8 @@ contract LaunchpegFactory is
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs
+        uint256 _amountForDevs,
+        bool _enableBatchReveal
     ) external override onlyOwner returns (address) {
         address launchpeg = Clones.clone(launchpegImplementation);
 
@@ -162,7 +164,7 @@ contract LaunchpegFactory is
                 .CollectionData({
                     name: _name,
                     symbol: _symbol,
-                    batchReveal: batchReveal,
+                    batchReveal: _enableBatchReveal ? batchReveal : address(0),
                     maxBatchSize: _maxBatchSize,
                     collectionSize: _collectionSize,
                     amountForDevs: _amountForDevs,
@@ -205,6 +207,7 @@ contract LaunchpegFactory is
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
+    /// @param _enableBatchReveal Flag to enable batch reveal for the collection
     /// @return flatLaunchpeg New FlatLaunchpeg address
     function createFlatLaunchpeg(
         string memory _name,
@@ -214,7 +217,8 @@ contract LaunchpegFactory is
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist
+        uint256 _amountForAllowlist,
+        bool _enableBatchReveal
     ) external override onlyOwner returns (address) {
         address flatLaunchpeg = Clones.clone(flatLaunchpegImplementation);
 
@@ -226,7 +230,7 @@ contract LaunchpegFactory is
                 .CollectionData({
                     name: _name,
                     symbol: _symbol,
-                    batchReveal: batchReveal,
+                    batchReveal: _enableBatchReveal ? batchReveal : address(0),
                     maxBatchSize: _maxBatchSize,
                     collectionSize: _collectionSize,
                     amountForDevs: _amountForDevs,

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -98,6 +98,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
 
     function salePrice() external view returns (uint256);
 
+    function initializeBatchReveal(address _batchReveal) external;
+
     function setRoyaltyInfo(address receiver, uint96 feePercent) external;
 
     function seedAllowlist(
@@ -118,8 +120,6 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
     function setPublicSaleEndTime(uint256 _publicSaleEndTime) external;
 
     function setWithdrawAVAXStartTime(uint256 _withdrawAVAXStartTime) external;
-
-    function setBatchReveal(address _batchReveal) external;
 
     function devMint(uint256 quantity) external;
 

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -41,7 +41,8 @@ interface ILaunchpegFactory {
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs
+        uint256 _amountForDevs,
+        bool _enableBatchReveal
     ) external returns (address);
 
     function createFlatLaunchpeg(
@@ -52,7 +53,8 @@ interface ILaunchpegFactory {
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist
+        uint256 _amountForAllowlist,
+        bool _enableBatchReveal
     ) external returns (address);
 
     function setLaunchpegImplementation(address _launchpegImplementation)

--- a/test/LaunchpegFactory.test.ts
+++ b/test/LaunchpegFactory.test.ts
@@ -187,7 +187,8 @@ describe('LaunchpegFactory', () => {
         config.collectionSize,
         config.amountForAuction,
         config.amountForAllowlist,
-        config.amountForDevs
+        config.amountForDevs,
+        config.enableBatchReveal
       )
 
       expect(await launchpegFactory.numLaunchpegs(0)).to.equal(1)
@@ -206,12 +207,47 @@ describe('LaunchpegFactory', () => {
         config.maxBatchSize,
         config.collectionSize,
         config.amountForDevs,
-        config.amountForAllowlist
+        config.amountForAllowlist,
+        config.enableBatchReveal
       )
 
       expect(await launchpegFactory.numLaunchpegs(1)).to.equal(1)
       const launchpegAddress = await launchpegFactory.allLaunchpegs(1, 0)
       expect(await launchpegFactory.isLaunchpeg(1, launchpegAddress)).to.equal(true)
+    })
+
+    it('Should not initialize batch reveal if disabled', async () => {
+      await launchpegFactory.createLaunchpeg(
+        'JoePEG',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForAuction,
+        config.amountForAllowlist,
+        config.amountForDevs,
+        false
+      )
+
+      const launchpegAddress = await launchpegFactory.allLaunchpegs(0, 0)
+      const launchpeg = await ethers.getContractAt('Launchpeg', launchpegAddress)
+      expect(await launchpeg.batchReveal()).to.equal(ethers.constants.AddressZero)
+
+      await launchpegFactory.createFlatLaunchpeg(
+        'JoePEG',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForDevs,
+        config.amountForAllowlist,
+        false
+      )
+      const flatLaunchpegAddress = await launchpegFactory.allLaunchpegs(1, 0)
+      const flatLaunchpeg = await ethers.getContractAt('FlatLaunchpeg', flatLaunchpegAddress)
+      expect(await flatLaunchpeg.batchReveal()).to.equal(ethers.constants.AddressZero)
     })
   })
 
@@ -261,7 +297,8 @@ describe('LaunchpegFactory', () => {
         config.collectionSize,
         config.amountForAuction,
         config.amountForAllowlist,
-        config.amountForDevs
+        config.amountForDevs,
+        config.enableBatchReveal
       )
       const launchpeg0Address = await launchpegFactory.allLaunchpegs(0, 0)
       const launchpeg0 = await ethers.getContractAt('Launchpeg', launchpeg0Address)
@@ -302,7 +339,8 @@ describe('LaunchpegFactory', () => {
         config.collectionSize,
         config.amountForAuction,
         config.amountForAllowlist,
-        config.amountForDevs
+        config.amountForDevs,
+        config.enableBatchReveal
       )
       const launchpegAddress = await launchpegFactory.allLaunchpegs(0, 0)
       const launchpeg = await ethers.getContractAt('Launchpeg', launchpegAddress)

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -19,6 +19,7 @@ export interface LaunchpegConfig {
   auctionDropInterval: BigNumber
   allowlistDiscount: number
   publicSaleDiscount: number
+  enableBatchReveal: boolean
   batchRevealSize: number
   batchRevealStart: BigNumber
   batchRevealInterval: BigNumber
@@ -58,6 +59,7 @@ export const getDefaultLaunchpegConfig = async (): Promise<LaunchpegConfig> => {
     auctionDropInterval: duration.minutes(20),
     allowlistDiscount: 0.1 * 10000,
     publicSaleDiscount: 0.2 * 10000,
+    enableBatchReveal: true,
     batchRevealSize: 1000,
     batchRevealStart: auctionStartTime.add(duration.minutes(REVEAL_START_OFFSET)),
     batchRevealInterval: duration.minutes(REVEAL_INTERVAL),


### PR DESCRIPTION
This PR updates the batch reveal implementation:

* Batch reveal can only be initialized (ie. set to non-zero address) once.
* Batch reveal cannot be updated (to any address, including zero address) once it is set.
* Batch reveal cannot be updated once the public sale end time has passed.